### PR TITLE
fix/zmb-18 - Fix the event propagation of the book card and the vote/join button inside the component

### DIFF
--- a/src/components/BookCard.vue
+++ b/src/components/BookCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="book-card px-5 py-5"
-    @click.self="this.$router.push(`/book/${book.id}`)"
+    @click.stop="this.$router.push(`/book/${book.id}`)"
   >
     <div class="book-card__info">
       <p
@@ -26,7 +26,7 @@
         <button-bc
           class="font-medium vote-btn"
           variant="secondary"
-          @click="addVote"
+          @click.stop="addVote"
           :class="{ 'user-vote': userVoted }"
         >
           {{ textBtn }}


### PR DESCRIPTION
Now you can click anywhere on the card to open the book's profile, except the vote/join button.